### PR TITLE
 Store the product IDs with the meta data

### DIFF
--- a/includes/class-wc-registrations-checkout.php
+++ b/includes/class-wc-registrations-checkout.php
@@ -243,6 +243,8 @@ class WC_Registrations_Checkout {
 					$date = get_post_meta( $_product->get_id(), 'attribute_dates', true );
 					$meta_name = ( $date ) ? "$title - $date" : $title;
 
+					$participants['product_id'] = $parent->get_id()
+					$participants['variation_product_id'] = $_product->get_id();
 					$participants['date'] = $meta_name;
 
 					// Process the fields

--- a/includes/class-wc-registrations-checkout.php
+++ b/includes/class-wc-registrations-checkout.php
@@ -243,7 +243,7 @@ class WC_Registrations_Checkout {
 					$date = get_post_meta( $_product->get_id(), 'attribute_dates', true );
 					$meta_name = ( $date ) ? "$title - $date" : $title;
 
-					$participants['product_id'] = $parent->get_id()
+					$participants['product_id'] = $parent->get_id();
 					$participants['variation_product_id'] = $_product->get_id();
 					$participants['date'] = $meta_name;
 


### PR DESCRIPTION
If an order has multiple products, it's not easy to match up the registration fields to the product, as the metadata array only contains the human readable product name and date. This change adds `product_id` and `variation_product_id` to the metadata array to remove that ambiguity.